### PR TITLE
Add Wolfgang.Etl.Csv.Benchmarks project

### DIFF
--- a/ETL-CSV.slnx
+++ b/ETL-CSV.slnx
@@ -41,7 +41,9 @@
     <File Path="scripts/Setup-Labels.ps1" />
     <File Path="scripts/setup.ps1" />
   </Folder>
-  <Folder Name="/benchmarks/" />
+  <Folder Name="/benchmarks/">
+    <Project Path="benchmarks/Wolfgang.Etl.Csv.Benchmarks/Wolfgang.Etl.Csv.Benchmarks.csproj" />
+  </Folder>
   <Folder Name="/examples/">
     <Project Path="examples/Wolfgang.Etl.Csv.Examples.DynamicTemplates/Wolfgang.Etl.Csv.Examples.DynamicTemplates.csproj" />
   </Folder>

--- a/benchmarks/.editorconfig
+++ b/benchmarks/.editorconfig
@@ -1,0 +1,15 @@
+# Analyzer rules relaxed for benchmark projects
+
+[*.cs]
+
+# AsyncFixer01: Remove async/await — benchmark methods use BenchmarkDotNet conventions
+dotnet_diagnostic.AsyncFixer01.severity = none
+
+# MA0004: Use ConfigureAwait(false) — not needed in benchmark harness
+dotnet_diagnostic.MA0004.severity = none
+
+# S1215: Remove use of GC.GetTotalMemory — required for memory benchmarks
+dotnet_diagnostic.S1215.severity = none
+
+# VSTHRD200: Use Async suffix — benchmark methods follow BenchmarkDotNet naming conventions
+dotnet_diagnostic.VSTHRD200.severity = none

--- a/benchmarks/Wolfgang.Etl.Csv.Benchmarks/BenchmarkRecord.cs
+++ b/benchmarks/Wolfgang.Etl.Csv.Benchmarks/BenchmarkRecord.cs
@@ -1,0 +1,27 @@
+namespace Wolfgang.Etl.Csv.Benchmarks;
+
+public class BenchmarkRecord
+{
+    [CsvColumn(Name = "first_name")]
+    public string FirstName { get; set; } = string.Empty;
+
+
+
+    [CsvColumn(Name = "last_name")]
+    public string LastName { get; set; } = string.Empty;
+
+
+
+    [CsvColumn(Name = "city")]
+    public string City { get; set; } = string.Empty;
+
+
+
+    [CsvColumn(Name = "zip_code")]
+    public int ZipCode { get; set; }
+
+
+
+    [CsvColumn(Name = "age")]
+    public int Age { get; set; }
+}

--- a/benchmarks/Wolfgang.Etl.Csv.Benchmarks/BenchmarkRecordWithDate.cs
+++ b/benchmarks/Wolfgang.Etl.Csv.Benchmarks/BenchmarkRecordWithDate.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Wolfgang.Etl.Csv.Benchmarks;
+
+public class BenchmarkRecordWithDate
+{
+    [CsvColumn(Name = "first_name")]
+    public string FirstName { get; set; } = string.Empty;
+
+
+
+    [CsvColumn(Name = "last_name")]
+    public string LastName { get; set; } = string.Empty;
+
+
+
+    [CsvColumn(Name = "birth_date", Format = "yyyy-MM-dd")]
+    public DateTime BirthDate { get; set; }
+
+
+
+    [CsvColumn(Name = "zip_code")]
+    public int ZipCode { get; set; }
+}

--- a/benchmarks/Wolfgang.Etl.Csv.Benchmarks/DateTimeBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.Csv.Benchmarks/DateTimeBenchmarks.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Wolfgang.Etl.Csv.Benchmarks;
+
+/// <summary>
+/// Exercises the reader/writer hot paths with a record that contains a
+/// <see cref="DateTime"/> field, isolating CsvHelper's date parse/format path.
+/// </summary>
+[MemoryDiagnoser]
+public class DateTimeBenchmarks
+{
+    private byte[] _data = Array.Empty<byte>();
+    private BenchmarkRecordWithDate[] _records = Array.Empty<BenchmarkRecordWithDate>();
+
+
+
+    [Params(10_000)]
+    public int RecordCount { get; set; }
+
+
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _records = new BenchmarkRecordWithDate[RecordCount];
+        var sb = new StringBuilder(RecordCount * 50);
+        sb.AppendLine("first_name,last_name,birth_date,zip_code");
+        for (var i = 0; i < RecordCount; i++)
+        {
+            var dob = new DateTime(1980, 1, 1).AddDays(i % 10000);
+            _records[i] = new BenchmarkRecordWithDate
+            {
+                FirstName = "John",
+                LastName = "Smith",
+                BirthDate = dob,
+                ZipCode = 98101,
+            };
+
+            sb.Append("John,Smith,");
+            sb.Append(dob.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+            sb.AppendLine(",98101");
+        }
+
+        _data = Encoding.UTF8.GetBytes(sb.ToString());
+    }
+
+
+
+    [Benchmark]
+    public async Task<int> Extract_Memory()
+    {
+        using var reader = new StreamReader(new MemoryStream(_data), Encoding.UTF8);
+        var extractor = new CsvExtractor<BenchmarkRecordWithDate>(reader);
+        var count = 0;
+        await foreach (var _ in extractor.ExtractAsync())
+        {
+            count++;
+        }
+        return count;
+    }
+
+
+
+    [Benchmark]
+    public async Task Load_Memory()
+    {
+        using var stream = new MemoryStream();
+        using var writer = new StreamWriter(stream, leaveOpen: true);
+        var loader = new CsvLoader<BenchmarkRecordWithDate>(writer);
+        await loader.LoadAsync(ToAsyncEnumerable(_records));
+        await writer.FlushAsync();
+    }
+
+
+
+    private static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(IEnumerable<T> source)
+    {
+        foreach (var item in source)
+        {
+            yield return item;
+        }
+        await Task.CompletedTask;
+    }
+}

--- a/benchmarks/Wolfgang.Etl.Csv.Benchmarks/ExtractorBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.Csv.Benchmarks/ExtractorBenchmarks.cs
@@ -1,0 +1,116 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Wolfgang.Etl.Csv.Benchmarks;
+
+[MemoryDiagnoser]
+public class ExtractorBenchmarks
+{
+    private byte[] _data = Array.Empty<byte>();
+    private string _filePath = string.Empty;
+
+
+
+    [Params(1_000, 10_000, 100_000)]
+    public int RecordCount { get; set; }
+
+
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        var sb = new StringBuilder(RecordCount * 50);
+        sb.AppendLine("first_name,last_name,city,zip_code,age");
+        for (var i = 0; i < RecordCount; i++)
+        {
+            sb.AppendLine("John,Smith,Seattle,98101,42");
+        }
+
+        _data = Encoding.UTF8.GetBytes(sb.ToString());
+
+        _filePath = Path.Combine(Path.GetTempPath(), $"csv_bench_extract_{RecordCount}.csv");
+        await File.WriteAllBytesAsync(_filePath, _data);
+    }
+
+
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        if (File.Exists(_filePath))
+        {
+            File.Delete(_filePath);
+        }
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // In-memory (MemoryStream) — isolates parsing cost from I/O
+    // ------------------------------------------------------------------
+
+    [Benchmark(Baseline = true)]
+    public async Task<int> Memory_TextReader()
+    {
+        using var reader = new StreamReader
+        (
+            new MemoryStream(_data),
+            Encoding.UTF8,
+            detectEncodingFromByteOrderMarks: false,
+            bufferSize: 1024,
+            leaveOpen: false
+        );
+        var extractor = new CsvExtractor<BenchmarkRecord>(reader);
+
+        var count = 0;
+        await foreach (var _ in extractor.ExtractAsync())
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // File-backed — shows real I/O effect of buffer sizing
+    // ------------------------------------------------------------------
+
+    [Benchmark]
+    public async Task<int> File_TextReader_1KB()
+    {
+        using var stream = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096);
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: 1024);
+        var extractor = new CsvExtractor<BenchmarkRecord>(reader);
+
+        var count = 0;
+        await foreach (var _ in extractor.ExtractAsync())
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+
+
+    [Benchmark]
+    public async Task<int> File_TextReader_64KB()
+    {
+        using var stream = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 65536);
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: 65536);
+        var extractor = new CsvExtractor<BenchmarkRecord>(reader);
+
+        var count = 0;
+        await foreach (var _ in extractor.ExtractAsync())
+        {
+            count++;
+        }
+
+        return count;
+    }
+}

--- a/benchmarks/Wolfgang.Etl.Csv.Benchmarks/LoaderBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.Csv.Benchmarks/LoaderBenchmarks.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Wolfgang.Etl.Csv.Benchmarks;
+
+[MemoryDiagnoser]
+public class LoaderBenchmarks
+{
+    private BenchmarkRecord[] _records = Array.Empty<BenchmarkRecord>();
+    private string _filePath = string.Empty;
+
+
+
+    [Params(1_000, 10_000, 100_000)]
+    public int RecordCount { get; set; }
+
+
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _records = new BenchmarkRecord[RecordCount];
+        for (var i = 0; i < RecordCount; i++)
+        {
+            _records[i] = new BenchmarkRecord
+            {
+                FirstName = "John",
+                LastName = "Smith",
+                City = "Seattle",
+                ZipCode = 98101,
+                Age = 42,
+            };
+        }
+
+        _filePath = Path.Combine(Path.GetTempPath(), $"csv_bench_load_{RecordCount}.csv");
+    }
+
+
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        if (File.Exists(_filePath))
+        {
+            File.Delete(_filePath);
+        }
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // In-memory (MemoryStream) — isolates formatting cost from I/O
+    // ------------------------------------------------------------------
+
+    [Benchmark(Baseline = true)]
+    public async Task Memory_TextWriter()
+    {
+        using var stream = new MemoryStream();
+        using var writer = new StreamWriter(stream, leaveOpen: true);
+        var loader = new CsvLoader<BenchmarkRecord>(writer);
+
+        await loader.LoadAsync(ToAsyncEnumerable(_records));
+        await writer.FlushAsync();
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // File-backed — shows real I/O effect of buffer sizing
+    // ------------------------------------------------------------------
+
+    [Benchmark]
+    public async Task File_TextWriter_1KB()
+    {
+        using var stream = new FileStream(_filePath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096);
+        using var writer = new StreamWriter(stream, bufferSize: 1024);
+        var loader = new CsvLoader<BenchmarkRecord>(writer);
+
+        await loader.LoadAsync(ToAsyncEnumerable(_records));
+        await writer.FlushAsync();
+    }
+
+
+
+    [Benchmark]
+    public async Task File_TextWriter_64KB()
+    {
+        using var stream = new FileStream(_filePath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 65536);
+        using var writer = new StreamWriter(stream, bufferSize: 65536);
+        var loader = new CsvLoader<BenchmarkRecord>(writer);
+
+        await loader.LoadAsync(ToAsyncEnumerable(_records));
+        await writer.FlushAsync();
+    }
+
+
+
+    private static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(IEnumerable<T> source)
+    {
+        foreach (var item in source)
+        {
+            yield return item;
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/benchmarks/Wolfgang.Etl.Csv.Benchmarks/PeakMemoryBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.Csv.Benchmarks/PeakMemoryBenchmarks.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Wolfgang.Etl.Csv.Benchmarks;
+
+[MemoryDiagnoser]
+public class PeakMemoryBenchmarks
+{
+    private byte[][] _dataBySize = Array.Empty<byte[]>();
+
+
+
+    [Params(0, 1, 1_000, 10_000, 100_000, 1_000_000)]
+    public int RecordCount { get; set; }
+
+
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _dataBySize = new byte[1][];
+        _dataBySize[0] = BuildData(RecordCount);
+    }
+
+
+
+    private static byte[] BuildData(int count)
+    {
+        var sb = new StringBuilder(Math.Max(64, count * 50));
+        sb.AppendLine("first_name,last_name,city,zip_code,age");
+        for (var i = 0; i < count; i++)
+        {
+            sb.AppendLine("John,Smith,Seattle,98101,42");
+        }
+
+        return Encoding.UTF8.GetBytes(sb.ToString());
+    }
+
+
+
+    [Benchmark]
+    public async Task<long> Extract_PeakMemory()
+    {
+        var before = GC.GetTotalMemory(forceFullCollection: true);
+
+        using var reader = new StreamReader(new MemoryStream(_dataBySize[0]), Encoding.UTF8);
+        var extractor = new CsvExtractor<BenchmarkRecord>(reader);
+
+        var count = 0;
+        await foreach (var _ in extractor.ExtractAsync())
+        {
+            count++;
+        }
+
+        var after = GC.GetTotalMemory(forceFullCollection: true);
+        return after - before;
+    }
+}

--- a/benchmarks/Wolfgang.Etl.Csv.Benchmarks/Program.cs
+++ b/benchmarks/Wolfgang.Etl.Csv.Benchmarks/Program.cs
@@ -1,0 +1,5 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args);

--- a/benchmarks/Wolfgang.Etl.Csv.Benchmarks/Wolfgang.Etl.Csv.Benchmarks.csproj
+++ b/benchmarks/Wolfgang.Etl.Csv.Benchmarks/Wolfgang.Etl.Csv.Benchmarks.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.Csv\Wolfgang.Etl.Csv.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+
+</Project>


### PR DESCRIPTION
## Summary
Mirrors the FixedWidth benchmark layout for the CSV library so we have an apples-to-apples perf reference.

- `ExtractorBenchmarks` — in-memory baseline + file-backed runs at 1 KB / 64 KB StreamReader buffers across 1k / 10k / 100k records
- `LoaderBenchmarks` — matching write-side counterpart for `CsvLoader<T>`
- `DateTimeBenchmarks` — isolates CsvHelper's date parse/format hot path
- `PeakMemoryBenchmarks` — `GC.GetTotalMemory` delta across 0..1M records

BenchmarkDotNet 0.15.8 on net10.0 only, ProjectReference to src, `BenchmarkSwitcher.FromAssembly` entry point.

## Notes
- Adds `benchmarks/.editorconfig` with the same analyzer relaxations FixedWidth uses (AsyncFixer01, MA0004, S1215, VSTHRD200). Benchmark methods follow BenchmarkDotNet naming/async conventions, and `PeakMemoryBenchmarks` requires `GC.GetTotalMemory`.
- Targets `initial-dev` rather than `main` because src/tests live there.
- New `benchmarks/.editorconfig` may trip the protected-config-files guard on PR CI — maintainer override likely needed.

## Test plan
- [x] `dotnet build -c Release` clean (0 warnings, 0 errors)
- [x] `BenchmarkSwitcher --list flat` discovers all 9 benchmarks
- [ ] Spot-run one benchmark locally before merging if desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)