### PR TITLE
pr.yaml: write protected config files as UTF-8 without BOM

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -630,7 +630,7 @@ jobs:
             $exists = git cat-file -e "main-branch:$configFile" 2>&1
             if ($LASTEXITCODE -eq 0) {
               Write-Host "  ✓ Copying $configFile from main branch"
-              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8 -NoNewline
+              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8NoBOM -NoNewline
             } else {
               Write-Host "  ℹ️  $configFile not found in main branch, skipping"
             }
@@ -645,7 +645,7 @@ jobs:
                 Write-Host "  ✓ Copying $file from main branch"
                 $dir = Split-Path -Parent $file
                 if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8 -NoNewline
+                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8NoBOM -NoNewline
               }
             }
           }
@@ -675,7 +675,7 @@ jobs:
             $exists = git cat-file -e "main-branch:$configFile" 2>&1
             if ($LASTEXITCODE -eq 0) {
               Write-Host "  ✓ Copying $configFile from main branch"
-              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8 -NoNewline
+              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8NoBOM -NoNewline
             } else {
               Write-Host "  ℹ️  $configFile not found in main branch, skipping"
             }
@@ -690,7 +690,7 @@ jobs:
                 Write-Host "  ✓ Copying $file from main branch"
                 $dir = Split-Path -Parent $file
                 if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8 -NoNewline
+                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8NoBOM -NoNewline
               }
             }
           }


### PR DESCRIPTION
Backport of [repo-template#339](https://github.com/Chris-Wolfgang/repo-template/pull/339).

The 'Fetch trusted configuration files from main branch' step writes the protected configs back via `Out-File -Encoding UTF8` (BOM-prefixed). The .NET analyzer engine appears to ignore BOM-prefixed `.editorconfig` files, so project severity overrides don't apply on CI — analyzers fire at default severity and `TreatWarningsAsErrors` escalates findings that pass locally.

This is a 4-line workflow-only change: `UTF8` → `UTF8NoBOM` at the four call sites. PowerShell 6+ supports the encoding token; `shell: pwsh` runners use PS 7+, so it's safe.

Diagnosed against [In-memory-Logger PR #32 / run 24996715587](https://github.com/Chris-Wolfgang/In-memory-Logger/actions/runs/24996715587/job/73195928572).

🤖 Generated with [Claude Code](https://claude.com/claude-code)