### PR TITLE
Add PublicAPI baseline files for breaking-change tracking (#43)

### DIFF
--- a/src/Wolfgang.Etl.Csv/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.Csv/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Wolfgang.Etl.Csv/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.Csv/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable


### PR DESCRIPTION
## Summary

Adds the two `PublicAPI.*.txt` baseline files that `Microsoft.CodeAnalysis.PublicApiAnalyzers` needs to activate. The analyzer was already wired in `Directory.Build.props` with `Exists()` guards (per-project opt-in); this PR provides the opt-in for `src/Wolfgang.Etl.Csv/`.

Closes #43.

## Files

| File | Content |
|---|---|
| `src/Wolfgang.Etl.Csv/PublicAPI.Shipped.txt` | `#nullable enable` header only |
| `src/Wolfgang.Etl.Csv/PublicAPI.Unshipped.txt` | `#nullable enable` header only |

## Why empty baselines

`Shipped.txt` is **correctly empty** — Wolfgang.Etl.Csv 0.1.0 hasn't published to NuGet yet, so nothing has technically "shipped". Once 0.1.0 publishes, the maintainer can graduate the 0.1.0 surface into `Shipped.txt`.

`Unshipped.txt` is empty as a baseline. As public API gets added or changed in subsequent PRs, the analyzer surfaces RS0016 (symbol not in declared API) / RS0017 (declared symbol not in code) diagnostics that prompt updates — either via Visual Studio's "Add to public API" code-fix or manually.

## Stack position

Top of Stack 1 (csproj hygiene). Stack 2 (#61 placeholder cleanup) is independent and will base on `initial-dev` separately.

## Test plan

- [ ] CI green
- [ ] After merge, a follow-up PR that adds a new public class triggers RS0016