### PR TITLE
Replace last template placeholder in docfx index.md (#61)

### DIFF
--- a/docfx_project/docs/index.md
+++ b/docfx_project/docs/index.md
@@ -1,4 +1,4 @@
-# {{PROJECT_NAME}} Documentation
+# Wolfgang.Etl.Csv Documentation
 
 Welcome to the documentation section. Browse the topics in the navigation menu to get started.
 


### PR DESCRIPTION
## Summary

Replaces the last real `{{...}}` placeholder in repo content — `{{PROJECT_NAME}}` on line 1 of `docfx_project/docs/index.md` — with `Wolfgang.Etl.Csv`.

Closes #61.

## Sweep results

```
grep -rn '{{[A-Z_]' --include='*.md' --include='*.cs' --include='*.csproj' --include='*.yaml'
```

After this PR, only one match remains:

- `docs/DOCFX-VERSION-PICKER.md:125` — prose documenting that the inlined version-picker HTML deliberately does NOT use template placeholders. Not a real placeholder.

(`.github/workflows/*` excluded from sweep — those use GitHub-Actions `${{ }}` expression syntax which is correct.)

## Stack position

Stack 2 (cleanup), independent of Stack 1 (csproj hygiene — #97).

## Test plan

- [ ] CI green
- [ ] DocFX index page renders with "Wolfgang.Etl.Csv Documentation" as the H1