### PR TITLE
Align AssemblyVersion/FileVersion with 0.1.0 (#24)

### DIFF
--- a/src/Wolfgang.Etl.Csv/Wolfgang.Etl.Csv.csproj
+++ b/src/Wolfgang.Etl.Csv/Wolfgang.Etl.Csv.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <Version>0.1.0</Version>
-    <AssemblyVersion>1.0.0</AssemblyVersion>
-    <FileVersion>1.0.0</FileVersion>
+    <AssemblyVersion>0.1.0.0</AssemblyVersion>
+    <FileVersion>0.1.0.0</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>Wolfgang.Etl.Csv</Title>
     <Authors>Chris Wolfgang</Authors>


### PR DESCRIPTION
## Summary

`AssemblyVersion` and `FileVersion` were stuck at the SDK default `1.0.0` while `<Version>` was `0.1.0` — the exact foot-gun #24 calls out. This PR sets both to `0.1.0.0` so all three metadata fields agree.

Closes #24.

## Diff

```diff
 <Version>0.1.0</Version>
-<AssemblyVersion>1.0.0</AssemblyVersion>
-<FileVersion>1.0.0</FileVersion>
+<AssemblyVersion>0.1.0.0</AssemblyVersion>
+<FileVersion>0.1.0.0</FileVersion>
```

## Test plan

- [x] `dotnet build -c Release` clean
- [ ] CI green
- [ ] After 0.1.0 publishes to NuGet, `Assembly.GetName().Version` returns `0.1.0.0`