### PR TITLE
BuildFromColumnMaps: validate duplicate property/index entries (#106)

### DIFF
--- a/src/Wolfgang.Etl.Csv/Mapping/CsvClassMapFactory.cs
+++ b/src/Wolfgang.Etl.Csv/Mapping/CsvClassMapFactory.cs
@@ -111,6 +111,8 @@ internal static class CsvClassMapFactory
             throw new ArgumentException("columnMaps must contain at least one entry.", nameof(columnMaps));
         }
 
+        ValidateNoDuplicates(columnMaps);
+
         var type = typeof(T);
         var properties = type
             .GetProperties(BindingFlags.Public | BindingFlags.Instance)
@@ -120,46 +122,93 @@ internal static class CsvClassMapFactory
 
         foreach (var col in columnMaps)
         {
-            if (!properties.TryGetValue(col.PropertyName, out var prop))
+            ApplyColumnMap(map, properties, type, col);
+        }
+
+        return map;
+    }
+
+
+
+    private static void ApplyColumnMap<T>
+    (
+        DefaultClassMap<T> map,
+        IReadOnlyDictionary<string, PropertyInfo> properties,
+        Type type,
+        CsvColumnMap col
+    )
+    {
+        if (!properties.TryGetValue(col.PropertyName, out var prop))
+        {
+            throw new ArgumentException
+            (
+                $"Property '{col.PropertyName}' was not found on type '{type.FullName}'.",
+                nameof(col)
+            );
+        }
+
+        var memberMap = map.Map(prop.DeclaringType ?? prop.ReflectedType!, prop);
+
+        // Index takes precedence over Name. Per CsvColumnMap.Name's docstring,
+        // Name is ignored when Index is non-negative. Apply only one binding
+        // path to avoid CsvHelper getting an ambiguous configuration.
+        if (col.Index >= 0)
+        {
+            memberMap.Index(col.Index);
+        }
+        else if (!string.IsNullOrEmpty(col.Name))
+        {
+            memberMap.Name(col.Name!);
+        }
+
+        if (col.Optional)
+        {
+            memberMap.Optional();
+        }
+
+        if (!string.IsNullOrEmpty(col.Format))
+        {
+            memberMap.TypeConverterOption.Format(col.Format!);
+        }
+
+        if (col.Default is not null)
+        {
+            memberMap.Default(col.Default);
+        }
+    }
+
+
+
+    private static void ValidateNoDuplicates(IReadOnlyList<CsvColumnMap> columnMaps)
+    {
+        var seenProperties = new HashSet<string>(StringComparer.Ordinal);
+        var seenIndices = new Dictionary<int, string>();
+
+        foreach (var col in columnMaps)
+        {
+            if (!seenProperties.Add(col.PropertyName))
             {
                 throw new ArgumentException
                 (
-                    $"Property '{col.PropertyName}' was not found on type '{type.FullName}'.",
+                    $"Duplicate column map for property '{col.PropertyName}'.",
                     nameof(columnMaps)
                 );
             }
 
-            var memberMap = map.Map(prop.DeclaringType ?? prop.ReflectedType!, prop);
+            if (col.Index >= 0 && seenIndices.TryGetValue(col.Index, out var firstProperty))
+            {
+                throw new ArgumentException
+                (
+                    $"Duplicate column index {col.Index} on property '{col.PropertyName}' (already bound by '{firstProperty}').",
+                    nameof(columnMaps)
+                );
+            }
 
-            // Index takes precedence over Name. Per CsvColumnMap.Name's docstring,
-            // Name is ignored when Index is non-negative. Apply only one binding
-            // path to avoid CsvHelper getting an ambiguous configuration.
             if (col.Index >= 0)
             {
-                memberMap.Index(col.Index);
-            }
-            else if (!string.IsNullOrEmpty(col.Name))
-            {
-                memberMap.Name(col.Name!);
-            }
-
-            if (col.Optional)
-            {
-                memberMap.Optional();
-            }
-
-            if (!string.IsNullOrEmpty(col.Format))
-            {
-                memberMap.TypeConverterOption.Format(col.Format!);
-            }
-
-            if (col.Default is not null)
-            {
-                memberMap.Default(col.Default);
+                seenIndices.Add(col.Index, col.PropertyName);
             }
         }
-
-        return map;
     }
 
 

--- a/tests/Wolfgang.Etl.Csv.Tests.Unit/CsvAttributeMappingTests.cs
+++ b/tests/Wolfgang.Etl.Csv.Tests.Unit/CsvAttributeMappingTests.cs
@@ -360,6 +360,66 @@ public class CsvAttributeMappingTests
 
 
     [Fact]
+    public void CsvClassMapFactory_BuildFromColumnMaps_when_columnMaps_contains_duplicate_property_throws()
+    {
+        var ex = Assert.Throws<ArgumentException>
+        (
+            () => CsvClassMapFactory.BuildFromColumnMaps<PriceRecord>
+            (
+                new[]
+                {
+                    new CsvColumnMap(nameof(PriceRecord.ProductNumber)) { Index = 0 },
+                    new CsvColumnMap(nameof(PriceRecord.ProductNumber)) { Index = 1 },
+                }
+            )
+        );
+
+        Assert.Contains("ProductNumber", ex.Message, StringComparison.Ordinal);
+    }
+
+
+
+    [Fact]
+    public void CsvClassMapFactory_BuildFromColumnMaps_when_columnMaps_contains_duplicate_index_throws()
+    {
+        var ex = Assert.Throws<ArgumentException>
+        (
+            () => CsvClassMapFactory.BuildFromColumnMaps<PriceRecord>
+            (
+                new[]
+                {
+                    new CsvColumnMap(nameof(PriceRecord.ProductNumber)) { Index = 2 },
+                    new CsvColumnMap(nameof(PriceRecord.RetailPrice))   { Index = 2 },
+                }
+            )
+        );
+
+        Assert.Contains("2", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("RetailPrice", ex.Message, StringComparison.Ordinal);
+    }
+
+
+
+    [Fact]
+    public void CsvClassMapFactory_BuildFromColumnMaps_when_columnMaps_has_negative_indices_allows_duplicates()
+    {
+        // Negative Index means "ignored" (Name path is used). Two distinct
+        // properties both at Index = -1 is not a conflict.
+        var map = CsvClassMapFactory.BuildFromColumnMaps<PriceRecord>
+        (
+            new[]
+            {
+                new CsvColumnMap(nameof(PriceRecord.ProductNumber)) { Name = "alpha" },
+                new CsvColumnMap(nameof(PriceRecord.RetailPrice))   { Name = "beta" },
+            }
+        );
+
+        Assert.NotNull(map);
+    }
+
+
+
+    [Fact]
     public Task ExtractAsync_when_runtime_ColumnMaps_names_unknown_property_throws()
     {
         var csv = "x\r\n";


### PR DESCRIPTION
## Summary

Closes #106. Adds boundary validation that throws `ArgumentException` for:
- Duplicate `PropertyName` entries in the same `ColumnMaps` list
- Duplicate non-negative `Index` values across different properties

Before: silently called `map.Map(prop)` twice for the same member, producing a ClassMap whose CsvHelper behaviour is undefined (last-wins in current versions, not contractual).

Negative `Index` is still allowed to repeat — `Index = -1` means *"use Name path"*, not a real index conflict.

## Refactor note

`BuildFromColumnMaps` grew past MA0051's 60-line ceiling after adding the validation hook. Extracted per-column mapping into `ApplyColumnMap` to keep both functions under the limit; pure refactor, no behaviour change in the mapping path.

## Tests

3 new tests in `CsvAttributeMappingTests`:
- `..._duplicate_property_throws` — same `PropertyName` twice → `ArgumentException` mentioning the property
- `..._duplicate_index_throws` — two properties at same non-negative `Index` → `ArgumentException` mentioning the index and second property
- `..._negative_indices_allows_duplicates` — two properties at `Index = -1` (default) → builds successfully (regression guard so the validation doesn't over-fire)

168/168 tests pass on net10.0 (165 → 168).