### PR TITLE
Count null GetRecord result as skipped item (#107)

### DIFF
--- a/src/Wolfgang.Etl.Csv/CsvExtractor.cs
+++ b/src/Wolfgang.Etl.Csv/CsvExtractor.cs
@@ -410,6 +410,12 @@ public sealed class CsvExtractor<[DynamicallyAccessedMembers(DynamicallyAccessed
             var record = csvReader.GetRecord<TRecord>();
             if (record is null)
             {
+                // CsvHelper can produce null for reference-typed TRecord when its
+                // type converters resolve every column to null. Count as skipped
+                // so totals reconcile against the raw row count instead of
+                // silently dropping the row.
+                IncrementCurrentSkippedItemCount();
+                CsvLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
                 continue;
             }
 


### PR DESCRIPTION
## Summary

Closes #107.

CsvHelper's `GetRecord<T>()` can return `null` for reference-typed `TRecord` in edge cases (custom type converters that resolve every column to null, certain ClassMap shapes). Previously the null branch executed `continue` without updating any counter — neither extracted nor skipped — so progress totals didn't reconcile against the raw row count.

## Change

```diff
 if (record is null)
 {
+    // CsvHelper can produce null for reference-typed TRecord when its
+    // type converters resolve every column to null. Count as skipped
+    // so totals reconcile against the raw row count instead of
+    // silently dropping the row.
+    IncrementCurrentSkippedItemCount();
+    CsvLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
     continue;
 }
```

## Test coverage note

This is **defensive code**. With stock CsvHelper 33.1.0 and the public-API path the extractor exposes (`OnReadingExceptionOccurred` always returns true → rethrow), `GetRecord<T>()` doesn't return null in normal flow. No new unit test forces the path because forcing it requires a custom `ITypeConverter` registered into CsvHelper's internal `CsvContext`, which the extractor doesn't expose.

The existing 165 tests still pass with no regression.

The change is observable behaviorally: if a future CsvHelper change, custom converter, or AOT-related instantiation failure makes the path reachable, the caller's `CsvExtractorProgress.CurrentSkippedItemCount` will reflect it instead of silently dropping rows.