### PR TITLE
Cache runtime ClassMaps in BuildFromColumnMaps (#104)

### DIFF
--- a/src/Wolfgang.Etl.Csv/Mapping/CsvClassMapFactory.cs
+++ b/src/Wolfgang.Etl.Csv/Mapping/CsvClassMapFactory.cs
@@ -24,6 +24,47 @@ internal static class CsvClassMapFactory
     // Caching the negative result avoids re-reflecting on every extraction.
     private static readonly ConcurrentDictionary<Type, ClassMap?> Cache = new();
 
+    // Runtime-maps cache: keyed by (TRecord, ColumnMaps reference identity).
+    // Two callers passing distinct list instances with identical content still
+    // pay reflection once each — by-reference is the only safe key here
+    // because CsvColumnMap is mutable (Index/Name/Format/Default are init-only
+    // on the type but the list itself can be repopulated). Long-running
+    // services that reuse a single ColumnMaps instance across many extractions
+    // hit this cache; one-shot callers see no benefit but no regression.
+    private static readonly ConcurrentDictionary<RuntimeMapKey, ClassMap> RuntimeMapCache = new();
+
+
+
+    private readonly struct RuntimeMapKey : IEquatable<RuntimeMapKey>
+    {
+        public RuntimeMapKey(Type recordType, IReadOnlyList<CsvColumnMap> columnMaps)
+        {
+            RecordType = recordType;
+            ColumnMaps = columnMaps;
+        }
+
+        public Type RecordType { get; }
+
+        public IReadOnlyList<CsvColumnMap> ColumnMaps { get; }
+
+        public bool Equals(RuntimeMapKey other) =>
+            RecordType == other.RecordType
+            && ReferenceEquals(ColumnMaps, other.ColumnMaps);
+
+        public override bool Equals(object? obj) =>
+            obj is RuntimeMapKey other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hash = RecordType.GetHashCode();
+                hash = (hash * 31) + System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(ColumnMaps);
+                return hash;
+            }
+        }
+    }
+
 
 
     /// <summary>
@@ -91,6 +132,13 @@ internal static class CsvClassMapFactory
     /// <see cref="CsvColumnMap"/> descriptors. Used when the layout is selected at
     /// runtime (e.g. from configuration or a database) rather than via attributes.
     /// </summary>
+    /// <remarks>
+    /// Cached by <c>(typeof(T), columnMaps reference identity)</c>: passing the
+    /// same <paramref name="columnMaps"/> instance to subsequent calls returns the
+    /// cached <see cref="ClassMap{T}"/> without re-reflecting. Callers running
+    /// long-lived services should reuse a single <c>ColumnMaps</c> instance per
+    /// template to amortize the reflection cost.
+    /// </remarks>
     /// <typeparam name="T">The record type being mapped.</typeparam>
     /// <param name="columnMaps">Runtime column descriptors. Must be non-empty.</param>
     /// <exception cref="ArgumentNullException"><paramref name="columnMaps"/> is <c>null</c>.</exception>
@@ -113,6 +161,24 @@ internal static class CsvClassMapFactory
 
         ValidateNoDuplicates(columnMaps);
 
+        var key = new RuntimeMapKey(typeof(T), columnMaps);
+        if (RuntimeMapCache.TryGetValue(key, out var cached))
+        {
+            return (ClassMap<T>)cached;
+        }
+
+        var built = BuildClassMapFromColumnMaps<T>(columnMaps);
+        return (ClassMap<T>)RuntimeMapCache.GetOrAdd(key, built);
+    }
+
+
+
+    [RequiresUnreferencedCode("Reflects over the public properties of T to build a CsvHelper ClassMap from runtime column descriptors.")]
+    private static ClassMap<T> BuildClassMapFromColumnMaps<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>
+    (
+        IReadOnlyList<CsvColumnMap> columnMaps
+    )
+    {
         var type = typeof(T);
         var properties = type
             .GetProperties(BindingFlags.Public | BindingFlags.Instance)

--- a/tests/Wolfgang.Etl.Csv.Tests.Unit/CsvAttributeMappingTests.cs
+++ b/tests/Wolfgang.Etl.Csv.Tests.Unit/CsvAttributeMappingTests.cs
@@ -420,6 +420,48 @@ public class CsvAttributeMappingTests
 
 
     [Fact]
+    public void CsvClassMapFactory_BuildFromColumnMaps_when_same_list_passed_twice_returns_cached_instance()
+    {
+        // Reuse the SAME list reference across two calls — must hit the cache
+        // and return the identical ClassMap instance the second time.
+        var columnMaps = new[]
+        {
+            new CsvColumnMap(nameof(PriceRecord.ProductNumber)) { Index = 0 },
+            new CsvColumnMap(nameof(PriceRecord.RetailPrice))   { Index = 1 },
+        };
+
+        var first  = CsvClassMapFactory.BuildFromColumnMaps<PriceRecord>(columnMaps);
+        var second = CsvClassMapFactory.BuildFromColumnMaps<PriceRecord>(columnMaps);
+
+        Assert.Same(first, second);
+    }
+
+
+
+    [Fact]
+    public void CsvClassMapFactory_BuildFromColumnMaps_when_distinct_list_instances_with_same_content_returns_separate_maps()
+    {
+        // Two distinct list instances — even with content-identical entries —
+        // must NOT collide. The cache is reference-keyed by design because
+        // CsvColumnMap is mutable and structural equality could over-cache.
+        var listA = new[]
+        {
+            new CsvColumnMap(nameof(PriceRecord.ProductNumber)) { Index = 0 },
+        };
+        var listB = new[]
+        {
+            new CsvColumnMap(nameof(PriceRecord.ProductNumber)) { Index = 0 },
+        };
+
+        var mapA = CsvClassMapFactory.BuildFromColumnMaps<PriceRecord>(listA);
+        var mapB = CsvClassMapFactory.BuildFromColumnMaps<PriceRecord>(listB);
+
+        Assert.NotSame(mapA, mapB);
+    }
+
+
+
+    [Fact]
     public Task ExtractAsync_when_runtime_ColumnMaps_names_unknown_property_throws()
     {
         var csv = "x\r\n";


### PR DESCRIPTION
## Summary

Closes #104. Reuses cached `ClassMap<T>` when the same `ColumnMaps` instance is passed across multiple `CsvExtractor`/`CsvLoader` constructions.

## Design

Cache key: `(typeof(T), ColumnMaps reference identity)`.

**Reference identity is intentional.** `CsvColumnMap` is mutable (the list can be repopulated in place, individual entries' `Name`/`Index`/etc. are init-only on the type but the list slot can be reassigned). Structural equality would over-cache when callers mutate a list between extractions. Long-running services typically construct a single `ColumnMaps` instance per template at startup and reuse it — that pattern hits this cache; one-shot callers see no benefit but no regression.

Implementation: `ConcurrentDictionary<RuntimeMapKey, ClassMap>` with a `readonly struct RuntimeMapKey` keyed on `Type` + `RuntimeHelpers.GetHashCode(ColumnMaps)`. `Equals` uses `ReferenceEquals` on the list.

Build logic extracted into a private `BuildClassMapFromColumnMaps<T>` so the cache wrapper stays compact.

## Tests

2 new tests:
- `..._when_same_list_passed_twice_returns_cached_instance` — `Assert.Same(first, second)` proves the cache fires
- `..._when_distinct_list_instances_with_same_content_returns_separate_maps` — `Assert.NotSame(mapA, mapB)` proves the cache doesn't over-fire on content equality

167/167 tests pass on net10.0.

## XML doc

The public `BuildFromColumnMaps` summary now describes the cache contract so callers know to reuse their `ColumnMaps` list for the perf benefit.