### PR TITLE
Trim/AOT: annotate public ctors RequiresUnreferencedCode + document not trim-safe (#105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,15 @@ the underlying exception, which still propagates out of `ExtractAsync`.
 | .NET Core | .NET Core 3.1 |
 | .NET | .NET 5.0, .NET 6.0, .NET 7.0, .NET 8.0, .NET 9.0, .NET 10.0 |
 
+### Trim / NativeAOT
+
+**Wolfgang.Etl.Csv is not trim-safe and not NativeAOT-compatible.** It depends on [CsvHelper](https://joshclose.github.io/CsvHelper/), which reflects over the record type's members (including type-converter constructors and members beyond what `DynamicallyAccessedMembers(PublicProperties)` can express) to build readers, writers, and type converters at runtime.
+
+The public `CsvExtractor` and `CsvLoader` constructors are annotated `[RequiresUnreferencedCode]`. Consumer projects with `PublishTrimmed=true` will see `IL2026` warnings on every call site, prompting the caller to either:
+- Suppress at the call site (acknowledges the risk), or
+- Annotate the calling method `[RequiresUnreferencedCode]` (propagates the contract), or
+- Avoid trimming for assemblies that use this library.
+
 ---
 
 ## 🔍 Code Quality & Static Analysis

--- a/src/Wolfgang.Etl.Csv/CsvExtractor.cs
+++ b/src/Wolfgang.Etl.Csv/CsvExtractor.cs
@@ -51,6 +51,7 @@ public sealed class CsvExtractor<[DynamicallyAccessedMembers(DynamicallyAccessed
     /// </summary>
     /// <param name="streamReader">The <see cref="StreamReader"/> to read CSV data from.</param>
     /// <exception cref="ArgumentNullException"><paramref name="streamReader"/> is <c>null</c>.</exception>
+    [RequiresUnreferencedCode("CsvExtractor uses CsvHelper, which reflects over TRecord's members beyond what DynamicallyAccessedMembers can express (type converter constructors, non-public setters in some flows). The library is not trim/NativeAOT safe.")]
     public CsvExtractor
     (
         StreamReader streamReader
@@ -70,6 +71,7 @@ public sealed class CsvExtractor<[DynamicallyAccessedMembers(DynamicallyAccessed
     /// <exception cref="ArgumentNullException">
     /// <paramref name="streamReader"/> or <paramref name="logger"/> is <c>null</c>.
     /// </exception>
+    [RequiresUnreferencedCode("CsvExtractor uses CsvHelper, which reflects over TRecord's members beyond what DynamicallyAccessedMembers can express (type converter constructors, non-public setters in some flows). The library is not trim/NativeAOT safe.")]
     public CsvExtractor
     (
         StreamReader streamReader,

--- a/src/Wolfgang.Etl.Csv/CsvLoader.cs
+++ b/src/Wolfgang.Etl.Csv/CsvLoader.cs
@@ -46,6 +46,7 @@ public sealed class CsvLoader<[DynamicallyAccessedMembers(DynamicallyAccessedMem
     /// </summary>
     /// <param name="streamWriter">The <see cref="StreamWriter"/> to write CSV data to.</param>
     /// <exception cref="ArgumentNullException"><paramref name="streamWriter"/> is <c>null</c>.</exception>
+    [RequiresUnreferencedCode("CsvLoader uses CsvHelper, which reflects over TRecord's members beyond what DynamicallyAccessedMembers can express (type converter constructors, non-public getters in some flows). The library is not trim/NativeAOT safe.")]
     public CsvLoader
     (
         StreamWriter streamWriter
@@ -65,6 +66,7 @@ public sealed class CsvLoader<[DynamicallyAccessedMembers(DynamicallyAccessedMem
     /// <exception cref="ArgumentNullException">
     /// <paramref name="streamWriter"/> or <paramref name="logger"/> is <c>null</c>.
     /// </exception>
+    [RequiresUnreferencedCode("CsvLoader uses CsvHelper, which reflects over TRecord's members beyond what DynamicallyAccessedMembers can express (type converter constructors, non-public getters in some flows). The library is not trim/NativeAOT safe.")]
     public CsvLoader
     (
         StreamWriter streamWriter,


### PR DESCRIPTION
## Summary

Closes #105.

The class-level `[DynamicallyAccessedMembers(PublicProperties)]` on `TRecord` understated what CsvHelper actually needs at runtime — type-converter constructors, non-public setters in certain converter flows, expression-tree-based member access. Callers with `PublishTrimmed=true` would compile cleanly and fail at runtime.

This PR makes the contract honest at the build layer.

## Changes

### Code
Add `[RequiresUnreferencedCode]` to the **4 public ctors**:
- `CsvExtractor<TRecord>(StreamReader)`
- `CsvExtractor<TRecord>(StreamReader, ILogger<CsvExtractor<TRecord>>)`
- `CsvLoader<TRecord>(StreamWriter)`
- `CsvLoader<TRecord>(StreamWriter, ILogger<CsvLoader<TRecord>>)`

Internal test-only ctors (with `IProgressTimer` injection) intentionally don't carry the attribute — they're internal API and tests don't trim.

### Docs
README's `## 🎯 Target Frameworks` section now has a **Trim / NativeAOT** subsection declaring the library is **not trim-safe and not NativeAOT-compatible**, and listing the three options consumers have when they do trim:
- Suppress at the call site
- Annotate the calling method `[RequiresUnreferencedCode]` (propagates the contract)
- Exclude the library from trimming

## Why not `[RequiresDynamicCode]` too?

CsvHelper's expression-tree emission technically warrants `RequiresDynamicCode` (NativeAOT failure surface). Skipped because:
- `RequiresDynamicCodeAttribute` was added in .NET 7; this library targets net462 / netstandard2.0 too. We'd need to ship a polyfill.
- `RequiresUnreferencedCode` already covers most realistic consumer cases (trimming is more common than NativeAOT).
- Can be added later if NativeAOT consumer demand materializes.

## Verification
- Build clean (0 warnings, 0 errors)
- 165/165 tests pass on net10.0
- No new IL2026 surfaced in own build because nothing in this repo opts into trim. Consumer projects that do opt in will surface them at their call sites — that's the intended behaviour.