### PR TITLE
Governance docs batch: ADRs + migration scaffold + DR runbook + OSSF Scorecard (#82 #83 #84 #85)

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,62 @@
+name: OSSF Scorecard
+
+# Runs the OpenSSF Scorecard automated security-posture audit and uploads
+# the results to the Security tab (Code scanning). Provides a public scorecard
+# badge consumers can use to evaluate this package's supply-chain posture.
+#
+# References:
+# - https://github.com/ossf/scorecard-action
+# - https://securityscorecards.dev/
+
+on:
+  schedule:
+    # Sunday 06:00 UTC — matches stryker.yaml's weekly cadence.
+    - cron: '0 6 * * 0'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Top-level read-only default; jobs declare narrower writes where required.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Required for uploading results to the code-scanning dashboard.
+      security-events: write
+      # Required to read the repository content for the analysis.
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        # SHA-pinned per repo convention for third-party actions.
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46  # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # publish_results: true uploads to the public Scorecard registry so
+          # the badge resolves on the README. Safe — only summary metrics are
+          # published, never code.
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning dashboard
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,32 @@
+# NNNN — Short title (verb + noun)
+
+- **Status:** Proposed | Accepted | Superseded by [NNNN](NNNN-slug.md) | Deprecated
+- **Date:** YYYY-MM-DD
+- **Decision maker(s):** @handle, @handle
+
+## Context
+
+What's the situation that requires a decision? What forces are at play (technical constraints, business goals, fleet conventions, prior commitments)? Keep this section factual — describe the world as it is, not the choice you're about to make.
+
+## Decision
+
+The choice in one or two sentences. Lead with the verb: "We will use X for Y."
+
+## Consequences
+
+What follows from this decision?
+
+- **Positive:** what gets easier, what we gain
+- **Negative:** what gets harder, what we close off
+- **Neutral:** changes that aren't clearly good or bad but are worth flagging
+
+## Alternatives considered
+
+- **Option A** — short description, and why it was rejected
+- **Option B** — short description, and why it was rejected
+- (Don't pad — only list alternatives that were genuinely on the table)
+
+## Related
+
+- ADRs that this one builds on, supersedes, or interacts with
+- Issues, PRs, or external docs that informed the decision

--- a/docs/adr/0001-csvhelper-as-internal-parser.md
+++ b/docs/adr/0001-csvhelper-as-internal-parser.md
@@ -1,0 +1,52 @@
+# 0001 — CsvHelper as the internal parser, parser-agnostic public surface
+
+- **Status:** Accepted
+- **Date:** 2026-06-20
+- **Decision maker(s):** @Chris-Wolfgang
+
+## Context
+
+Wolfgang.Etl.Csv 0.1.0 needs a CSV parser. The realistic options in the .NET ecosystem are:
+
+1. **[CsvHelper](https://joshclose.github.io/CsvHelper/)** — mature (~12 years), 280M+ NuGet downloads, MS-PL / Apache 2.0 dual-license, broad RFC 4180 + non-standard CSV quirks coverage, type converters and mapping fluently composable, allocates more than strictly necessary for high-throughput scenarios.
+2. **[Sep](https://github.com/nietras/Sep)** — modern (2023), Apache 2.0, allocation-free hot path, vectorized parsing, ~10× CsvHelper's throughput in benchmarks. Smaller surface than CsvHelper: limited bespoke-CSV-quirk coverage, less mature type-converter ecosystem.
+3. **Roll our own** — full control over allocations and API surface but a perpetual maintenance burden for edge cases (escapes, quote handling, encoding, BOM, comments, multi-line fields).
+
+The library has two constraints that shape the choice:
+
+- **Drop-in compatible with Wolfgang.Etl.Abstractions's `ExtractorBase<T, TProgress>` / `LoaderBase<T, TProgress>` contracts.** The parser's record-iteration model needs to map cleanly onto the async-yield + progress + cancellation pattern those contracts define.
+- **Should not lock consumers into the parser's API surface.** Consumers wire `CsvExtractor<T>` into their pipelines and shouldn't have to absorb a parser swap if we later need one.
+
+## Decision
+
+We will use **CsvHelper** as the internal parser for 0.1.0, behind a public surface that does **not leak any CsvHelper types**.
+
+The wrapper types — `CsvTrimOptions`, `CsvBadDataInfo`, `CsvShouldQuoteContext`, `CsvReadingExceptionInfo`, `CsvColumnAttribute`, `CsvIgnoreAttribute`, `CsvColumnMap` — translate consumer intent to CsvHelper's configuration model at extraction/load time. CsvHelper itself is referenced as an internal package dependency; nothing in `public class CsvExtractor<T>` or `public class CsvLoader<T>` exposes a CsvHelper type, enum, or interface.
+
+## Consequences
+
+**Positive:**
+- Day-one production-grade RFC 4180 + non-standard CSV coverage. Doesn't need its own parser test suite at the byte level.
+- Type-converter ecosystem comes for free (DateTime formats, enums, custom converters per property).
+- Mapping fluency (`ClassMap<T>`, attribute-driven, runtime-driven) is reusable inside our `CsvClassMapFactory` without inventing a parallel abstraction.
+- License (MS-PL / Apache 2.0) is MIT-compatible — no consumer-side license fragmentation.
+- Future parser swap (e.g. to Sep, for an allocation-free 1.0) is internal-only: zero consumer breakage.
+
+**Negative:**
+- Allocations per record are higher than a hand-tuned or Sep-based pipeline. Not appropriate as-is for hot-path streaming of millions of rows per second — consumers in that regime will need to roll their own or wait for a Sep-backed variant.
+- CsvHelper is not trim/AOT-safe (reflects beyond `DynamicallyAccessedMembers(PublicProperties)` for type converters). The library inherits this constraint and surfaces it honestly via `[RequiresUnreferencedCode]` on public ctors and a "Trim / NativeAOT" subsection in the README (see [#105](https://github.com/Chris-Wolfgang/ETL-Csv/issues/105)).
+- Wrapper types add a thin maintenance burden — when CsvHelper adds a new configuration knob worth exposing, the wrapper needs a corresponding addition.
+
+**Neutral:**
+- The wrapper-translation pattern adds a layer of indirection that's barely measurable in microbenchmarks but real in profile traces. For 0.1.0's use cases (typical ETL throughput in the hundreds of thousands of rows/sec), this is well within the noise.
+
+## Alternatives considered
+
+- **Sep** — rejected for 0.1.0 because its type-converter and configuration ecosystem is less mature than CsvHelper's, and the library needs to support attribute-driven mapping with custom formats / defaults / optional columns on day one. Reconsidering for a future 1.0 / 2.0 allocation-free variant is the entire point of keeping the public surface parser-agnostic.
+- **Roll our own** — rejected because building a production-grade RFC 4180 parser plus type-converter system plus configurable encoding/BOM/comment handling is a multi-month effort that adds zero differentiated value over CsvHelper. The differentiation is in the ETL contract (progress, async-yield, cancellation, mapping factory), not in the parser.
+
+## Related
+
+- [Wolfgang.Etl.Abstractions](https://github.com/Chris-Wolfgang/ETL-Abstractions) — the `ExtractorBase` / `LoaderBase` contracts this library implements.
+- [CsvHelper docs](https://joshclose.github.io/CsvHelper/)
+- [#105](https://github.com/Chris-Wolfgang/ETL-Csv/issues/105) — trim/AOT honesty contract.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,26 @@
+# Architecture Decision Records
+
+This directory captures the **why** behind significant architectural choices in Wolfgang.Etl.Csv.
+
+Code comments explain *what* a line of code does and *how* — ADRs explain *why* the larger decision was made, what alternatives were considered, and what the tradeoffs were. They survive refactors, package upgrades, and team turnover.
+
+## When to write an ADR
+
+Write one when:
+
+- A choice locks in a tradeoff that's not obvious from the code
+- A choice closes off a path that a future maintainer might reasonably want to take
+- The decision was contentious or had non-trivial alternatives
+- The rationale lives only in a PR thread, issue comment, or Slack message — places where it'll be hard to find later
+
+Don't write one for tactical choices captured fine by code comments or PR descriptions.
+
+## Format
+
+Each ADR is a single markdown file named `<NNNN>-<short-slug>.md`, where `NNNN` is a 4-digit zero-padded sequence number starting at `0001`. Use `0000-template.md` as the starting point.
+
+## Index
+
+| # | Title | Status |
+|---|---|---|
+| [0001](0001-csvhelper-as-internal-parser.md) | CsvHelper as the internal parser, parser-agnostic public surface | Accepted |

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -1,0 +1,152 @@
+# Disaster Recovery
+
+Runbook for compromise scenarios affecting Wolfgang.Etl.Csv's NuGet package, GitHub repository, or maintainer credentials. Designed to be readable end-to-end during an incident — most of the value comes from the first 30 seconds of clarity when the worst has happened.
+
+## When to use this
+
+Trigger the relevant section the moment you suspect — not when you can prove — that one of these is true:
+
+- Your NuGet.org API key has leaked or been used by anyone else
+- Your GitHub maintainer account is compromised (suspicious login, unfamiliar PAT, MFA bypassed)
+- An unauthorized NuGet package has been published under `Wolfgang.Etl.*`
+- A malicious commit, tag, or release has appeared in `Chris-Wolfgang/ETL-Csv` (or any sibling repo) that you did not author
+- The `gh-pages` branch contains content you didn't deploy
+
+False positives are cheap. Investigation while the attacker still has access is not.
+
+---
+
+## Scenario 1: NuGet API key compromised
+
+**Detection signals:**
+- NuGet.org email about a new push you didn't make
+- New version visible at https://www.nuget.org/packages/Wolfgang.Etl.Csv/ that doesn't match any GitHub Release
+- `release.yaml` succeeded but you didn't tag a release
+- A consumer reports installing a package version you didn't ship
+
+**Immediate actions (first 10 minutes):**
+
+1. **Revoke the leaked key first, before anything else.**
+   - Go to https://www.nuget.org/account/apikeys → find the key labeled `ETL-Csv` (or whatever you used) → click **Delete**.
+   - If you can't identify which key, delete **all** keys on the account. Re-create only the one you need next.
+2. **Rotate the GitHub secret.**
+   - Settings → Secrets and variables → Actions → `NUGET_API_KEY` → Update with a fresh key.
+3. **Audit recent pushes.**
+   - `nuget.exe list Wolfgang.Etl.Csv -AllVersions -PreRelease` (or check the package's Versions page on NuGet.org)
+   - Compare to `git tag` and `gh release list --repo Chris-Wolfgang/ETL-Csv`. Any NuGet version without a matching tag and release is unauthorized.
+
+**Containment (next hour):**
+
+1. **Unlist (do not delete) any unauthorized package versions.**
+   - Find the package on NuGet.org → Manage → Listing → uncheck **List in search results**.
+   - NuGet does **not** allow deletion after 72 hours of upload, and even within 72 hours, deletion does not protect consumers who already restored the package. Unlisting prevents new installs without breaking restore for existing lockfiles that pinned a known-good version.
+2. **Publish a security advisory.**
+   - https://github.com/Chris-Wolfgang/ETL-Csv/security/advisories → New draft
+   - Include: which versions are affected, what to look for, what to upgrade to, what the malicious payload did (if known)
+3. **Yank the consumer-side recommendation.**
+   - Update `README.md` to recommend the latest known-good version explicitly
+   - Add a `[!WARNING]` callout at the top of README for as long as the bad version remains discoverable
+
+**Recovery (next day):**
+
+1. Ship a clean patch release with the version number immediately after the compromised one (e.g. if `0.1.5` was malicious, ship `0.1.6` — don't reuse `0.1.5`).
+2. Email any known downstream consumers if you have a way to.
+3. Post-mortem the leak: how did the key escape? CI logs? Local clipboard? Browser extension? Address the root cause before generating a new key.
+
+---
+
+## Scenario 2: GitHub maintainer account compromised
+
+**Detection signals:**
+- GitHub email about a new SSH key, PAT, or OAuth app authorization you didn't create
+- Commits in `Chris-Wolfgang/ETL-Csv` (or sibling repos) authored as you but pushed from an unfamiliar location
+- Workflow runs triggered by `workflow_dispatch` that you didn't trigger
+- New collaborators on repos you own
+
+**Immediate actions (first 10 minutes):**
+
+1. **Force a session reset.**
+   - https://github.com/settings/sessions → Revoke all sessions
+   - Sign out everywhere — including any GitHub Mobile devices
+2. **Rotate the account password.**
+   - Use a fresh password not derived from any previous one
+3. **Re-enroll MFA from a known-clean device.**
+   - https://github.com/settings/two_factor_authentication → Reconfigure
+   - If the existing TOTP seed may have leaked, delete and regenerate
+4. **Audit credentials.**
+   - https://github.com/settings/keys → review all SSH and GPG keys; delete any you don't recognize
+   - https://github.com/settings/tokens → revoke **all** PATs; you'll re-create the ones you actually need
+   - https://github.com/settings/applications → review OAuth apps; revoke any you don't recognize
+
+**Containment (next hour):**
+
+1. **Pause CI on `main` for sibling repos until audit is complete.**
+   - Settings → Actions → General → Disable Actions for any repo where unauthorized commits or workflow runs occurred
+   - This stops a half-completed attack from continuing to deploy/publish while you investigate
+2. **Force-push-protect the default branches.**
+   - Verify the "Protect main branch" ruleset (or equivalent on sibling repos) is intact and `block_force_pushes: true`
+3. **Audit recent commits across all owned repos.**
+   ```bash
+   for r in $(gh repo list Chris-Wolfgang --json name --jq '.[].name'); do
+     gh api "repos/Chris-Wolfgang/$r/commits?since=$(date -d '7 days ago' --iso-8601)" \
+       --jq '.[] | "\(.commit.author.date) \(.commit.author.name) \(.sha[0:7]) \(.commit.message | split("\n")[0])"'
+   done
+   ```
+4. **Audit recently published NuGet releases** — see Scenario 1 (the attacker may have used the API key during the window they had access).
+
+**Recovery (next day):**
+
+1. Re-create only the PATs and SSH keys you actively need. Scope each to the minimum permissions.
+2. Re-enable Actions on the paused repos.
+3. Publish a security advisory disclosing the timeline if any consumer-facing code or package was affected.
+4. Post-mortem: how was the account compromised? Reused password? Phished MFA? Stolen session token? Address the root cause.
+
+---
+
+## Scenario 3: Malicious commit / tag / release in the repository
+
+**Detection signals:**
+- Unfamiliar commits visible in `git log` or the GitHub Activity tab
+- A tag you didn't create (verify with `git tag --list 'v*'` against `gh release list`)
+- A release published by an unfamiliar actor
+- `gh-pages` showing content that doesn't match the last successful `docfx.yaml` deploy
+
+**Immediate actions:**
+
+1. **Don't delete anything yet.** Forensic record matters more than fast cleanup.
+2. **Take a screenshot or full log dump.**
+   - `gh run list --repo Chris-Wolfgang/ETL-Csv --created '>=YYYY-MM-DD' > runs.txt`
+   - `gh release list --repo Chris-Wolfgang/ETL-Csv > releases.txt`
+   - `git log --all --pretty=fuller > log.txt` (preserve author/committer metadata)
+3. **Verify the attacker's current access is severed** — follow Scenario 2 actions before doing repo-level cleanup.
+4. **Roll back `main`.**
+   - Identify the last known-good commit you trust: `git log --pretty='%H %an %ae %s' | head -50`
+   - If branch protection blocks the rollback, temporarily relax the ruleset (admin override), reset, force-push, then re-enable protection.
+5. **Delete unauthorized tags and releases.**
+   - `gh release delete vX.Y.Z --repo Chris-Wolfgang/ETL-Csv --cleanup-tag`
+6. **Unlist unauthorized NuGet versions** — see Scenario 1.
+
+**Recovery:**
+
+- Same as Scenarios 1 and 2 depending on what was affected.
+- Publish a security advisory.
+
+---
+
+## Preventive measures (not reactive, but mentioned here so they're remembered)
+
+- `NUGET_API_KEY` should be scoped to **a single package glob** (`Wolfgang.Etl.Csv`), with **a short expiration** (1 year max), and rotated proactively at every renewal — not just at compromise.
+- The maintainer GitHub account should require **hardware-backed MFA** (a security key, not just TOTP).
+- `pr.yaml` already runs all workflows from `main` via `pull_request_target` to prevent malicious PR-authored workflow modifications from being trusted; preserve that.
+- All third-party GitHub Actions in `.github/workflows/` are **SHA-pinned**, not tag-pinned. If a popular action's GitHub repo is compromised, our workflows continue running the known commit, not whatever the attacker has retagged as the "latest".
+- Dependabot is enabled (`nuget` + `github-actions` ecosystems) so a known-vulnerable transitive dependency surfaces as an automated PR instead of waiting for manual discovery.
+
+---
+
+## Who to contact
+
+- **NuGet.org security team:** account@nuget.org (response: ~1 business day)
+- **GitHub security team:** https://github.com/contact (escalate to `security@github.com` for active compromise)
+- **OSSF supply-chain security team:** https://openssf.org/community/ — best for cross-ecosystem coordination if the incident has fleet-wide implications
+
+If multiple repos in the `Chris-Wolfgang/*` org are affected, treat it as a coordinated supply-chain incident and open a single security advisory at the org level rather than per-repo.

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -1,0 +1,31 @@
+# Migration Guides
+
+Per-major-version upgrade guides for Wolfgang.Etl.Csv consumers.
+
+## Status
+
+No migration guides yet — Wolfgang.Etl.Csv is at **0.1.0**, the first public release.
+
+The first migration guide will appear here when a 1.0 or 2.0 ships with breaking changes. Until then, this directory exists as scaffolding so the structure is in place before it's needed.
+
+## Format
+
+Each guide is a single markdown file named `<from>-to-<to>.md` (e.g. `0.x-to-1.0.md`, `1.x-to-2.0.md`).
+
+A guide should include:
+
+1. **Summary** — one paragraph describing the scope of the change
+2. **Breaking changes** — table of removed/renamed/repurposed public API with before/after snippets
+3. **Behavioural changes** — semantics that changed even where the API didn't
+4. **Recommended migration order** — for guides covering multiple breaking changes, suggest a sequence consumers can follow incrementally
+5. **Automated rewrites** — code-fix analyzer rules, `dotnet format` patterns, or regex substitutions where applicable
+6. **Deprecations** — what to remove next, on what schedule
+
+## Cross-references
+
+When a release ships breaking changes, link the migration guide from:
+
+- The release notes on the [GitHub Releases page](https://github.com/Chris-Wolfgang/ETL-Csv/releases)
+- `CHANGELOG.md` under the relevant `[X.Y.Z]` section
+- The NuGet package description (or the PackageReleaseNotes property in the csproj)
+- The repo README's "Installation" section if the consumer-side change is more than a version bump


### PR DESCRIPTION
## Summary

Four governance/docs items landed together since none affect runtime behaviour and they share a single reviewable PR. Closes **#82**, **#83**, **#84**, **#85**.

## Changes

### `#85` OSSF Scorecard adoption
- `.github/workflows/scorecard.yaml` runs [`ossf/scorecard-action@v2.4.0`](https://github.com/ossf/scorecard-action) (SHA-pinned per repo convention) on weekly cron + push-to-main + workflow_dispatch
- Uploads SARIF to the Security tab + publishes the public Scorecard badge
- Permissions: `read-all` top-level, narrow writes on the analysis job only (security-events + id-token + actions read)

### `#82` Migration guides scaffold
- `docs/migration/README.md` — format spec, cross-reference checklist
- No actual guides yet (0.1.0 is the first release). Scaffold exists for when 1.0+ ships

### `#83` Architecture Decision Records
- `docs/adr/README.md` — when to write ADRs + index
- `docs/adr/0000-template.md` — starting template
- `docs/adr/0001-csvhelper-as-internal-parser.md` — captures the parser choice, Sep comparison, and trim/AOT honesty trade-off

### `#84` Disaster recovery runbook
- `docs/disaster-recovery.md` covers three scenarios with detection signals → first-10-minutes immediate actions → containment → recovery for each:
  1. NuGet API key compromise
  2. GitHub maintainer account compromise
  3. Malicious commit / tag / release in the repository
- Closes with preventive measures already in place + escalation contacts (NuGet, GitHub, OSSF)

## Protected-files note

`scorecard.yaml` is a **new workflow file**. The `pr.yaml` Detect .NET Projects guard treats workflow files as protected even on add — same case as PR #103 hit. Expect **admin-bypass merge** to land this one. Same single-PR-with-admin-bypass posture as the previous protected-files-split PRs.

If you'd prefer the docs (#82, #83, #84) land separately from #85, easy to split — say the word.

## Out of scope (not done this PR)

- `docfx_project/api/*.yml` generation artifacts surfaced as untracked locally — should be added to `.gitignore` in a separate small PR (not blocking anything)