### PR TITLE
Add workflow-security.yaml: actionlint + zizmor on every PR (#86)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,12 @@
+# actionlint baseline configuration.
+#
+# Suppress accepted-as-intentional findings here, one per `paths:` entry,
+# with a rationale comment. Empty today — accumulate suppressions as
+# real findings are reviewed and either fixed or formally accepted.
+#
+# Reference: https://github.com/rhysd/actionlint/blob/main/docs/config.md
+
+self-hosted-runner:
+  # We don't use any self-hosted runners on this repo. If a workflow ever
+  # adds one, list its label here.
+  labels: []

--- a/.github/workflows/workflow-security.yaml
+++ b/.github/workflows/workflow-security.yaml
@@ -1,0 +1,94 @@
+name: Workflow Security
+
+# Lints the GitHub Actions YAML files themselves for:
+#   - syntax errors and common mistakes (actionlint)
+#   - workflow-security vulnerabilities — untrusted-input injection, missing
+#     permissions blocks, expression-context secret expansion, unpinned
+#     third-party actions (zizmor)
+#
+# Complementary to CodeQL (which scans .cs source) and to S2's manual
+# Actions-hardening review. Strictly additive; does not gate merge today,
+# but a high-severity new finding will surface as a PR annotation.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.zizmor.yml'
+  push:
+    branches: [main, vNext]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.zizmor.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        # Pinned to v1.7.7. actionlint validates workflow YAML for syntax,
+        # expression errors, common pitfalls (e.g. missing `if:` on a step
+        # that needs one), and shellcheck on `run:` scripts.
+        # The official action installs the binary and runs it; see
+        # https://github.com/rhysd/actionlint/blob/main/docs/usage.md.
+        uses: docker://rhysd/actionlint:1.7.7
+        with:
+          args: -color=never
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      # SARIF upload to the Security tab requires security-events: write.
+      security-events: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install zizmor
+        # zizmor is published to PyPI; pin to a known release for
+        # reproducibility. https://woodruffw.github.io/zizmor/
+        run: pip install --user 'zizmor==1.5.2'
+
+      - name: Run zizmor (SARIF output)
+        # --offline avoids GitHub API calls during the lint (no rate-limit
+        # surprises on busy days). --persona auditor enables stricter rules
+        # appropriate for a library shipping to the public NuGet feed.
+        run: |
+          zizmor --offline --persona auditor --format sarif \
+            .github/workflows/ > zizmor.sarif || true
+        # `|| true` keeps the step from short-circuiting on finding, so
+        # SARIF still uploads. Findings surface as PR annotations via the
+        # upload step below; severity threshold tightening is tracked in
+        # the issue's Acceptance criteria for a follow-up.
+
+      - name: Upload SARIF to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: zizmor.sarif
+          category: zizmor

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -1,0 +1,18 @@
+# zizmor baseline configuration.
+#
+# Suppress accepted-as-intentional findings here, with rule_id + path +
+# rationale. Empty today — accumulate suppressions as real findings are
+# reviewed and either fixed or formally accepted.
+#
+# Format: https://woodruffw.github.io/zizmor/configuration/
+#
+# Example for future reference:
+#
+# rules:
+#   dangerous-triggers:
+#     ignore:
+#       - path: .github/workflows/pr.yaml
+#         comment: |
+#           pull_request_target is intentional here so PR validation runs
+#           from main's trusted version of the workflow rather than the
+#           PR-author-controlled HEAD. See S2 hardening notes.


### PR DESCRIPTION
## Summary

Closes #86.

Adds two complementary workflow YAML linters that run on every PR touching `.github/workflows/`:

| Tool | Catches |
|---|---|
| **actionlint** (Docker `rhysd/actionlint:1.7.7`) | Syntax errors, expression-context bugs, common workflow pitfalls, shellcheck on `run:` scripts |
| **zizmor** (PyPI `zizmor==1.5.2`, `--persona auditor`) | Workflow-security vulnerabilities — untrusted input injection, missing/overly-permissive `permissions:` blocks, expression-context secret expansion, unpinned third-party actions |

zizmor SARIF results upload to the code-scanning dashboard so findings surface as PR annotations.

## Files

| File | Purpose |
|---|---|
| `.github/workflows/workflow-security.yaml` | Two jobs (actionlint, zizmor) on PR + push-to-main/vNext + workflow_dispatch |
| `.github/actionlint.yaml` | actionlint baseline config — empty today, accumulates suppressions per-finding |
| `.zizmor.yml` | zizmor baseline config — empty today, ditto |

## Scope choices

- **Triggered by path filter** on `.github/workflows/**` — keeps this workflow off the critical path of unrelated PRs.
- **No merge gate today.** Findings surface; severity-threshold tightening is tracked as a follow-up so the first real PR doesn't get blocked by an unexpected baseline.
- **Strictly additive** to CodeQL (which scans `.cs` source) and to #41's manual Actions hardening.

## Test plan

- [ ] PR CI runs both jobs
- [ ] zizmor SARIF appears in Security → Code scanning
- [ ] If actionlint or zizmor surface findings on the existing 8 workflows, fix in this branch before merge
