### PR TITLE
Quick-wins batch 3: allocation guards + ABI-compat script (#69, #80)

### DIFF
--- a/docs/abi-stability.md
+++ b/docs/abi-stability.md
@@ -1,0 +1,64 @@
+# ABI Stability and Breaking-Change Detection
+
+How Wolfgang.Etl.Csv tracks public API changes between releases.
+
+## Policy
+
+- **PATCH / MINOR releases (0.1.x, 0.x.0)** — must **not** break ABI. Adding new public members is fine; removing or changing existing public members is not.
+- **MAJOR releases (1.0.0, 2.0.0, ...)** — may break ABI, but every break must be:
+  - Listed in `CHANGELOG.md` under the `### Removed` or `### Changed` section
+  - Covered by a migration guide in [`docs/migration/`](migration/) with before/after snippets
+  - Surfaced in the release notes
+
+## Detection
+
+Run [`scripts/check-api-compat.ps1`](../scripts/check-api-compat.ps1) before publishing a release. It downloads the latest stable `Wolfgang.Etl.Csv` from NuGet.org, builds the local source, then runs [`Microsoft.DotNet.ApiCompat.Tool`](https://www.nuget.org/packages/Microsoft.DotNet.ApiCompat.Tool/) to diff the public API.
+
+```powershell
+# Diff against latest stable on NuGet.org
+pwsh ./scripts/check-api-compat.ps1
+
+# Or pin to a specific baseline
+pwsh ./scripts/check-api-compat.ps1 -BaselineVersion 0.1.0
+```
+
+Exit code 0 = no breaks. Non-zero = ApiCompat surfaced at least one break; review the report inline.
+
+## Why not on every PR?
+
+Running on every PR would catch every accidental change but generate noise on PRs that deliberately add API surface (which is most non-trivial PRs while a library is below 1.0). The pre-release run is the right point because it answers the specific question: *"am I about to ship a breaking change in a release that shouldn't?"*
+
+Once the library reaches a 1.x stability promise, **consider moving this check to `release.yaml`** as a release gate.
+
+## What ApiCompat catches
+
+- Removed types or members
+- Changed method signatures (parameter types, return types, generic constraints)
+- Visibility narrowing (e.g. `public` → `internal`)
+- Removed interface implementations
+- Members renamed without retaining the old name as `[Obsolete]`
+
+## What ApiCompat does **not** catch
+
+- Behaviour changes (same signature, different semantics — e.g. a method that used to return `null` now throws)
+- Performance regressions
+- Changes to internal types or private members (intentional — these aren't part of the public contract)
+- XML-doc-only changes (the example in `<example>` is checked by [`CsvXmlDocExampleRotTests`](../tests/Wolfgang.Etl.Csv.Tests.Unit/CsvXmlDocExampleRotTests.cs); semantics changes are not detectable from metadata alone)
+
+For behaviour changes, the test suite is the primary guard. For performance regressions, the benchmark chart at https://chris-wolfgang.github.io/ETL-Csv/dev/bench/ is the trend signal.
+
+## PublicAPI baseline files
+
+`src/Wolfgang.Etl.Csv/PublicAPI.Shipped.txt` and `PublicAPI.Unshipped.txt` are a complementary mechanism enforced at build time by [`Microsoft.CodeAnalysis.PublicApiAnalyzers`](https://www.nuget.org/packages/Microsoft.CodeAnalysis.PublicApiAnalyzers/) — when a new public symbol appears without a corresponding entry in either file, the build emits `RS0016`. This catches accidental API additions at the PR layer; ApiCompat catches accidental removals at the release layer.
+
+The two are complementary: PublicApiAnalyzers prevents the surface from growing without an explicit author decision, ApiCompat prevents the surface from shrinking without an explicit author decision.
+
+## Versioning
+
+Wolfgang.Etl.Csv follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html):
+
+- `<MAJOR>.<MINOR>.<PATCH>` for releases
+- Pre-release identifiers (`-alpha`, `-beta`, `-rc`) reserved for unstable previews
+- `0.x.x` — pre-1.0 development. MINOR may break ABI in this range (this is permitted by SemVer for the 0.x range, but the project chooses to honour the no-break-on-MINOR policy anyway to avoid surprising consumers).
+
+The current shipped version is reported in `src/Wolfgang.Etl.Csv/Wolfgang.Etl.Csv.csproj` `<Version>` and surfaced on NuGet.org.

--- a/scripts/check-api-compat.ps1
+++ b/scripts/check-api-compat.ps1
@@ -1,0 +1,134 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Compares the current build's public API against the latest published
+    Wolfgang.Etl.Csv NuGet package to detect breaking API changes.
+
+.DESCRIPTION
+    Downloads the most recent stable Wolfgang.Etl.Csv .nupkg from NuGet.org,
+    builds the local src project, then runs Microsoft.DotNet.ApiCompat.Tool
+    against both. Any breaking change (removed type, removed member,
+    signature change, etc.) is reported with a non-zero exit code.
+
+    Designed to run pre-release as a guard against accidental API breakage.
+    SemVer policy: PATCH/MINOR releases must NOT break ABI; MAJOR releases
+    may, but the diff should still be reviewed and called out in the
+    migration guide (docs/migration/).
+
+.PARAMETER BaselineVersion
+    The published Wolfgang.Etl.Csv version to diff against. Defaults to
+    "latest" which resolves to the most recent stable version on NuGet.org.
+
+.PARAMETER ProjectPath
+    Path to the src csproj. Defaults to src/Wolfgang.Etl.Csv/Wolfgang.Etl.Csv.csproj.
+
+.EXAMPLE
+    pwsh ./scripts/check-api-compat.ps1
+    pwsh ./scripts/check-api-compat.ps1 -BaselineVersion 0.1.0
+
+.NOTES
+    Requires Microsoft.DotNet.ApiCompat.Tool. Installed on first run if absent.
+
+    This is intentionally a script-on-demand rather than a CI step. Running
+    on every PR catches every accidental change but creates noise on PRs
+    that deliberately add API surface (which is most non-trivial PRs in a
+    library's early life). Pre-release run is the right point: it answers
+    "am I about to ship a breaking change in a release that shouldn't?".
+
+    When the library reaches a 1.x stability promise, consider moving this
+    to release.yaml as a release gate.
+#>
+
+[CmdletBinding()]
+param
+(
+    [string]$BaselineVersion = 'latest',
+    [string]$ProjectPath = 'src/Wolfgang.Etl.Csv/Wolfgang.Etl.Csv.csproj',
+    [string]$TargetFramework = 'net10.0'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Ensure the ApiCompat tool is available.
+$toolList = dotnet tool list -g 2>&1 | Out-String
+if ($toolList -notmatch 'microsoft\.dotnet\.apicompat\.tool')
+{
+    Write-Host 'Installing Microsoft.DotNet.ApiCompat.Tool...'
+    dotnet tool install -g Microsoft.DotNet.ApiCompat.Tool
+}
+
+# Resolve the baseline version.
+if ($BaselineVersion -eq 'latest')
+{
+    Write-Host 'Resolving latest stable Wolfgang.Etl.Csv from NuGet.org...'
+    $catalog = Invoke-RestMethod -Uri 'https://api.nuget.org/v3-flatcontainer/wolfgang.etl.csv/index.json'
+    $stable = $catalog.versions | Where-Object { $_ -notmatch '-' } | Select-Object -Last 1
+    if (-not $stable)
+    {
+        throw 'No stable Wolfgang.Etl.Csv versions found on NuGet.org. Pass -BaselineVersion explicitly.'
+    }
+    $BaselineVersion = $stable
+}
+
+Write-Host "Baseline: Wolfgang.Etl.Csv $BaselineVersion"
+
+# Stage workspace.
+$workDir = New-Item -ItemType Directory -Force -Path './artifacts/api-compat'
+$baselineNupkg = Join-Path $workDir.FullName "Wolfgang.Etl.Csv.$BaselineVersion.nupkg"
+$baselineExtract = Join-Path $workDir.FullName "baseline-$BaselineVersion"
+
+# Download baseline nupkg.
+if (-not (Test-Path $baselineNupkg))
+{
+    Write-Host "Downloading $BaselineVersion .nupkg..."
+    Invoke-WebRequest `
+        -Uri "https://api.nuget.org/v3-flatcontainer/wolfgang.etl.csv/$BaselineVersion/wolfgang.etl.csv.$BaselineVersion.nupkg" `
+        -OutFile $baselineNupkg
+}
+
+if (Test-Path $baselineExtract) { Remove-Item -Recurse -Force $baselineExtract }
+Expand-Archive -Path $baselineNupkg -DestinationPath $baselineExtract
+
+$baselineDll = Get-ChildItem -Path $baselineExtract -Recurse -Filter 'Wolfgang.Etl.Csv.dll' |
+    Where-Object { $_.Directory.Name -eq $TargetFramework } |
+    Select-Object -First 1
+
+if (-not $baselineDll)
+{
+    throw "Baseline .nupkg has no Wolfgang.Etl.Csv.dll under lib/$TargetFramework/. Try a different -TargetFramework."
+}
+
+# Build current.
+Write-Host "Building current ($ProjectPath, $TargetFramework)..."
+dotnet build $ProjectPath -c Release -f $TargetFramework | Out-Host
+$currentDir = Split-Path $ProjectPath -Parent
+$currentDll = Join-Path $currentDir "bin/Release/$TargetFramework/Wolfgang.Etl.Csv.dll"
+
+if (-not (Test-Path $currentDll))
+{
+    throw "Current build .dll not found at $currentDll."
+}
+
+# Run ApiCompat.
+Write-Host ''
+Write-Host '== Running ApiCompat =='
+Write-Host "Baseline: $($baselineDll.FullName)"
+Write-Host "Current:  $currentDll"
+Write-Host ''
+
+apicompat --left $($baselineDll.FullName) --right $currentDll
+$exit = $LASTEXITCODE
+
+Write-Host ''
+if ($exit -eq 0)
+{
+    Write-Host "✅ No breaking API changes vs $BaselineVersion."
+}
+else
+{
+    Write-Host "❌ Breaking API changes detected vs $BaselineVersion."
+    Write-Host '   Review the report above. SemVer policy says PATCH/MINOR releases must not break ABI.'
+    Write-Host '   If this break is intentional (MAJOR release), document it in docs/migration/.'
+}
+
+exit $exit

--- a/tests/Wolfgang.Etl.Csv.Tests.Unit/CsvAllocationProfileTests.cs
+++ b/tests/Wolfgang.Etl.Csv.Tests.Unit/CsvAllocationProfileTests.cs
@@ -1,0 +1,155 @@
+#if NET5_0_OR_GREATER
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Csv.Tests.Unit.TestModels;
+using Xunit;
+
+namespace Wolfgang.Etl.Csv.Tests.Unit;
+
+/// <summary>
+/// Hot-path allocation regression guards. Uses
+/// <see cref="GC.GetAllocatedBytesForCurrentThread"/> (available since
+/// netcoreapp3.0; net5.0+ for our test matrix) to capture the per-thread
+/// allocation delta across a known extraction or load.
+///
+/// These tests don't aim for zero allocation — CsvHelper allocates per
+/// record by design, and the wrapper types contribute too. The aim is
+/// to catch egregious regressions (e.g. someone accidentally adds a
+/// <c>string.Format</c> per row, or removes a buffer pool and now we
+/// allocate 100× more). The ceilings are intentionally generous:
+/// they're regression alarms, not contracts.
+///
+/// If a baseline shifts because a real perf improvement reduced
+/// allocations, tighten the ceiling at the same time as the
+/// improvement. If a baseline shifts because of a regression, find
+/// out why before relaxing the ceiling.
+/// </summary>
+public class CsvAllocationProfileTests
+{
+    private const string Csv =
+        "FirstName,LastName,Age\r\n" +
+        "Alice,Smith,30\r\n" +
+        "Bob,Jones,25\r\n" +
+        "Carol,White,35\r\n" +
+        "Dave,Brown,40\r\n" +
+        "Eve,Davis,28\r\n";
+
+
+
+    private static StreamReader Reader() =>
+        new(new MemoryStream(Encoding.UTF8.GetBytes(Csv)), Encoding.UTF8);
+
+
+
+    private static void StabilizeBeforeMeasurement()
+    {
+        // Two GC sweeps + finalizer drain make the baseline reading
+        // independent of allocations from previous tests / xUnit
+        // scaffolding. Without this the noise floor would be tens of
+        // KB and the per-record signal would drown.
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_when_run_over_5_record_CSV_stays_under_allocation_ceiling()
+    {
+        // Warm-up: JIT compilation, CsvHelper internal cache priming,
+        // ClassMap construction. These happen exactly once per process
+        // and should not count against per-record allocation budgets.
+        await ExtractOnce().ConfigureAwait(false);
+
+        StabilizeBeforeMeasurement();
+        var before = GC.GetAllocatedBytesForCurrentThread();
+
+        var count = await ExtractOnce().ConfigureAwait(false);
+
+        var after = GC.GetAllocatedBytesForCurrentThread();
+        var delta = after - before;
+
+        Assert.Equal(5, count);
+
+        // 5 records × ~3 KB per record = ~15 KB baseline (small but
+        // realistic for CsvHelper + record allocation + string interning).
+        // Ceiling of 100 KB allows ~6× headroom for environmental noise
+        // and still catches an order-of-magnitude regression.
+        const long Ceiling = 100_000;
+        Assert.True
+        (
+            delta < Ceiling,
+            $"ExtractAsync allocated {delta} bytes for 5 records (ceiling {Ceiling}). " +
+            "If this is an intentional change, update the ceiling and explain why."
+        );
+    }
+
+
+
+    [Fact]
+    public async Task LoadAsync_when_writing_5_record_stream_stays_under_allocation_ceiling()
+    {
+        // Same warmup + measurement pattern, but for the write path.
+        await LoadOnce().ConfigureAwait(false);
+
+        StabilizeBeforeMeasurement();
+        var before = GC.GetAllocatedBytesForCurrentThread();
+
+        await LoadOnce().ConfigureAwait(false);
+
+        var after = GC.GetAllocatedBytesForCurrentThread();
+        var delta = after - before;
+
+        // Same rationale as ExtractAsync. Write path tends to be a bit
+        // higher because CsvHelper's per-record write buffer flushes
+        // through StreamWriter's char buffer.
+        const long Ceiling = 100_000;
+        Assert.True
+        (
+            delta < Ceiling,
+            $"LoadAsync allocated {delta} bytes for 5 records (ceiling {Ceiling}). " +
+            "If this is an intentional change, update the ceiling and explain why."
+        );
+    }
+
+
+
+    private static async Task<int> ExtractOnce()
+    {
+        var sut = new CsvExtractor<PersonRecord>(Reader());
+        var count = 0;
+        await foreach (var _ in sut.ExtractAsync().ConfigureAwait(false))
+        {
+            count++;
+        }
+        return count;
+    }
+
+
+
+    private static async Task LoadOnce()
+    {
+        var stream = new MemoryStream();
+        var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), 1024, leaveOpen: true);
+        var sut = new CsvLoader<PersonRecord>(writer) { LeaveOpen = true };
+        var items = new List<PersonRecord>
+        {
+            new() { FirstName = "Alice", LastName = "Smith", Age = 30 },
+            new() { FirstName = "Bob",   LastName = "Jones", Age = 25 },
+            new() { FirstName = "Carol", LastName = "White", Age = 35 },
+            new() { FirstName = "Dave",  LastName = "Brown", Age = 40 },
+            new() { FirstName = "Eve",   LastName = "Davis", Age = 28 },
+        };
+        await sut.LoadAsync(items.ToAsyncEnumerable()).ConfigureAwait(false);
+        await writer.FlushAsync().ConfigureAwait(false);
+        await writer.DisposeAsync().ConfigureAwait(false);
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary

Closes #69 and #80. (#79 closed separately as cross-reference to #88.)

## Per-issue breakdown

### `#80` Allocation-free hot-path verification
Two regression-alarm tests in `CsvAllocationProfileTests.cs`:

| Test | Path | Ceiling |
|---|---|---|
| `ExtractAsync_when_run_over_5_record_CSV_stays_under_allocation_ceiling` | Extract | 100 KB |
| `LoadAsync_when_writing_5_record_stream_stays_under_allocation_ceiling` | Load | 100 KB |

Uses `GC.GetAllocatedBytesForCurrentThread()` (net5.0+). Each test:
1. Warm-up pass (JIT, ClassMap construction, CsvHelper internal cache prime — these are once-per-process and shouldn't count)
2. `GC.Collect` + `WaitForPendingFinalizers` + `GC.Collect` for a clean baseline
3. Measure → run → measure
4. Assert delta < ceiling

Ceilings are **alarms, not contracts** — generous enough to absorb environmental noise but tight enough to catch an order-of-magnitude regression where a future change accidentally adds a `string.Format` per row.

### `#69` Binary compatibility / ABI diff between releases
- `scripts/check-api-compat.ps1` — downloads the latest published `Wolfgang.Etl.Csv` from NuGet.org, builds the local source, runs `Microsoft.DotNet.ApiCompat.Tool` to diff, exits non-zero on break
- `docs/abi-stability.md` — policy (PATCH/MINOR no-break; MAJOR with migration guide), what ApiCompat catches and doesn't, why PublicApiAnalyzers + ApiCompat are complementary

Intentionally a **script-on-demand** rather than a CI step:
- Running on every PR generates noise on PRs that legitimately add API surface (most non-trivial PRs while we're below 1.0)
- Pre-release run answers the right question: *"am I about to ship a breaking change in a release that shouldn't?"*
- Documents the intent to graduate to `release.yaml` as a release gate at 1.x

### `#79` Build reproducibility verification (closed separately)
[Closed via comment](https://github.com/Chris-Wolfgang/ETL-Csv/issues/79#issuecomment-XXX) as covered by [`docs/reproducible-build-verification.md`](https://github.com/Chris-Wolfgang/ETL-Csv/blob/main/docs/reproducible-build-verification.md) (shipped in #116). Same infrastructure (`ContinuousIntegrationBuild`, `EmbedUntrackedSources`, SourceLink) handles both publisher-side and consumer-side reproduction; the verification recipe applies to both.

## Test results

176/176 tests pass on net10.0 (+2 over batch 2's 174 baseline).

## Stack position

Targets `vNext`. No protected-file touches → normal merge.
