### PR TITLE
Code review batch 4/4: ConfigureAwait + EventId scheme doc

### DIFF
--- a/src/Wolfgang.Etl.Csv/CsvLoader.cs
+++ b/src/Wolfgang.Etl.Csv/CsvLoader.cs
@@ -242,9 +242,14 @@ public sealed class CsvLoader<[DynamicallyAccessedMembers(DynamicallyAccessedMem
 
         CsvLogMessages.StartingOperation(_logger, OperationName, null);
 
-#pragma warning disable CA2007, MA0004
-        await using var csvWriter = new CsvWriter(_writer, BuildConfiguration(), LeaveOpen);
-#pragma warning restore CA2007, MA0004
+        // The `await using var` form doesn't compose with ConfigureAwait(false) —
+        // there's no way to ConfigureAwait the implicit DisposeAsync that runs at
+        // scope exit. Split into construction + explicit ConfiguredAsyncDisposable
+        // so the disposal continuation never captures the caller's
+        // SynchronizationContext (real deadlock risk on net462/netstandard targets
+        // where sync-over-async consumers exist in the wild).
+        var csvWriter = new CsvWriter(_writer, BuildConfiguration(), LeaveOpen);
+        await using var _csvWriterDisposal = csvWriter.ConfigureAwait(false);
 
         RegisterRecordMap(csvWriter.Context);
 

--- a/src/Wolfgang.Etl.Csv/CsvLogMessages.cs
+++ b/src/Wolfgang.Etl.Csv/CsvLogMessages.cs
@@ -7,6 +7,17 @@ namespace Wolfgang.Etl.Csv;
 /// Cached <see cref="LoggerMessage"/> delegates for high-performance structured logging
 /// across the CSV extractor and loader.
 /// </summary>
+/// <remarks>
+/// <para><b>EventId numbering scheme</b> — IDs are reserved by category so future maintainers
+/// don't reuse retired IDs (log aggregators key alerts on EventId; reuse confuses dashboards):</para>
+/// <list type="bullet">
+///   <item><description><c>1–9</c>: Lifecycle / general (currently 1=StartingOperation, 2=SkippedItem, 3=ReachedMaximumItemCount; 4–9 reserved)</description></item>
+///   <item><description><c>10–19</c>: Extractor-specific (10=ExtractedItem, 11=ExtractionCompleted, 12=IgnoredRow; 13 retired = removed default BadDataFound log per PII privacy; 14 retired = removed default ReadingExceptionOccurred log)</description></item>
+///   <item><description><c>20–29</c>: Loader-specific (20=LoadedItem, 21=LoadingCompleted; 22–29 reserved)</description></item>
+/// </list>
+/// <para>When adding a new event, use the next free ID within the appropriate category. Never reuse
+/// a retired ID — pick a fresh one even if the new event is conceptually similar.</para>
+/// </remarks>
 internal static class CsvLogMessages
 {
     internal static readonly Action<ILogger, string, Exception?> StartingOperation =


### PR DESCRIPTION
Code review batch 4 of 4 — final code-quality items.

## Changes

**CsvLoader.cs — `await using` ConfigureAwait:**
`await using var csvWriter = new CsvWriter(...)` had `#pragma warning disable CA2007, MA0004` acknowledging that there's no way to ConfigureAwait the implicit DisposeAsync. The suppression silenced the analyzer but the actual deadlock risk on `net462`/`netstandard2.0` targets (sync-over-async consumers) remained.

Refactored to split form:
```csharp
var csvWriter = new CsvWriter(_writer, BuildConfiguration(), LeaveOpen);
await using var _csvWriterDisposal = csvWriter.ConfigureAwait(false);
```
The disposable scope is identical; the SynchronizationContext capture on the disposal continuation is now explicitly suppressed. Pragma block removed — suppression no longer needed.

**CsvLogMessages.cs — EventId numbering doc:**
Added `<remarks>` documenting the EventId scheme (1–9 lifecycle, 10–19 extractor-specific, 20–29 loader-specific) and the retired-ID policy. 13 and 14 are retired (removed default `BadDataFound`/`ReadingExceptionOccurred` logs per the PII privacy refactor) — the doc warns future maintainers never to reuse them.

## Verification

Build clean (0/0 warnings/errors). 176/176 tests pass on net10.0.

## Stack position

4 of 4 — last code-review batch. Independent of batches 1, 2, 3.