### PR TITLE
Sync workflow-security.yaml + actionlint/zizmor config into main (admin bypass)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,12 @@
+# actionlint baseline configuration.
+#
+# Suppress accepted-as-intentional findings here, one per `paths:` entry,
+# with a rationale comment. Empty today — accumulate suppressions as
+# real findings are reviewed and either fixed or formally accepted.
+#
+# Reference: https://github.com/rhysd/actionlint/blob/main/docs/config.md
+
+self-hosted-runner:
+  # We don't use any self-hosted runners on this repo. If a workflow ever
+  # adds one, list its label here.
+  labels: []

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -233,10 +233,10 @@ jobs:
         id: check-projects
         run: |
           if git ls-files '*.csproj' '*.vbproj' '*.fsproj' | grep -q .; then
-            echo "has-projects=true" >> $GITHUB_OUTPUT
+            echo "has-projects=true" >> "$GITHUB_OUTPUT"
             echo "✅ Found .NET project files - .NET build and test jobs will run"
           else
-            echo "has-projects=false" >> $GITHUB_OUTPUT
+            echo "has-projects=false" >> "$GITHUB_OUTPUT"
             echo "ℹ️  No .NET project files found - skipping .NET build and test jobs"
           fi
 
@@ -538,10 +538,10 @@ jobs:
         id: check-coverage
         run: |
           if find TestResults -type f -name "coverage.cobertura.xml" 2>/dev/null | grep -q .; then
-            echo "has-coverage=true" >> $GITHUB_OUTPUT
+            echo "has-coverage=true" >> "$GITHUB_OUTPUT"
             echo "✅ Coverage files found"
           else
-            echo "has-coverage=false" >> $GITHUB_OUTPUT
+            echo "has-coverage=false" >> "$GITHUB_OUTPUT"
             echo "ℹ️  No coverage files found - skipping coverage report generation"
           fi
 

--- a/.github/workflows/workflow-security.yaml
+++ b/.github/workflows/workflow-security.yaml
@@ -1,0 +1,94 @@
+name: Workflow Security
+
+# Lints the GitHub Actions YAML files themselves for:
+#   - syntax errors and common mistakes (actionlint)
+#   - workflow-security vulnerabilities — untrusted-input injection, missing
+#     permissions blocks, expression-context secret expansion, unpinned
+#     third-party actions (zizmor)
+#
+# Complementary to CodeQL (which scans .cs source) and to S2's manual
+# Actions-hardening review. Strictly additive; does not gate merge today,
+# but a high-severity new finding will surface as a PR annotation.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.zizmor.yml'
+  push:
+    branches: [main, vNext]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.zizmor.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        # Pinned to v1.7.7. actionlint validates workflow YAML for syntax,
+        # expression errors, common pitfalls (e.g. missing `if:` on a step
+        # that needs one), and shellcheck on `run:` scripts.
+        # The official action installs the binary and runs it; see
+        # https://github.com/rhysd/actionlint/blob/main/docs/usage.md.
+        uses: docker://rhysd/actionlint:1.7.7
+        with:
+          args: -color=never
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      # SARIF upload to the Security tab requires security-events: write.
+      security-events: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install zizmor
+        # zizmor is published to PyPI; pin to a known release for
+        # reproducibility. https://woodruffw.github.io/zizmor/
+        run: pip install --user 'zizmor==1.5.2'
+
+      - name: Run zizmor (SARIF output)
+        # --offline avoids GitHub API calls during the lint (no rate-limit
+        # surprises on busy days). --persona auditor enables stricter rules
+        # appropriate for a library shipping to the public NuGet feed.
+        run: |
+          zizmor --offline --persona auditor --format sarif \
+            .github/workflows/ > zizmor.sarif || true
+        # `|| true` keeps the step from short-circuiting on finding, so
+        # SARIF still uploads. Findings surface as PR annotations via the
+        # upload step below; severity threshold tightening is tracked in
+        # the issue's Acceptance criteria for a follow-up.
+
+      - name: Upload SARIF to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: zizmor.sarif
+          category: zizmor

--- a/.github/workflows/workflow-security.yaml
+++ b/.github/workflows/workflow-security.yaml
@@ -47,9 +47,11 @@ jobs:
         # that needs one), and shellcheck on `run:` scripts.
         # The official action installs the binary and runs it; see
         # https://github.com/rhysd/actionlint/blob/main/docs/usage.md.
+        # No args needed — actionlint scans all workflow YAMLs by default.
+        # Don't pass `-color=never`; actionlint's CLI uses a boolean -color
+        # flag, not GNU-style key=value, so `-color=never` fails parse.
+        # Color is auto-disabled in non-TTY CI output anyway.
         uses: docker://rhysd/actionlint:1.7.7
-        with:
-          args: -color=never
 
   zizmor:
     name: zizmor

--- a/.github/workflows/workflow-security.yaml
+++ b/.github/workflows/workflow-security.yaml
@@ -42,16 +42,21 @@ jobs:
           persist-credentials: false
 
       - name: Run actionlint
-        # Pinned to v1.7.7. actionlint validates workflow YAML for syntax,
-        # expression errors, common pitfalls (e.g. missing `if:` on a step
-        # that needs one), and shellcheck on `run:` scripts.
-        # The official action installs the binary and runs it; see
-        # https://github.com/rhysd/actionlint/blob/main/docs/usage.md.
-        # No args needed — actionlint scans all workflow YAMLs by default.
-        # Don't pass `-color=never`; actionlint's CLI uses a boolean -color
-        # flag, not GNU-style key=value, so `-color=never` fails parse.
-        # Color is auto-disabled in non-TTY CI output anyway.
-        uses: docker://rhysd/actionlint:1.7.7
+        # Pinned to v1.7.7. Installation matches the maintainer's own
+        # recommendation in actionlint's README: download the binary via
+        # the official bash script and run it directly. Faster than a
+        # Docker pull, cleaner argv handling (no container ENTRYPOINT
+        # in the loop), and one fewer trust boundary.
+        #
+        # Script is fetched from the v1.7.7 tag for content-pinning —
+        # not from main — so a future change to download-actionlint.bash
+        # can't retroactively alter what this CI does.
+        run: |
+          curl -sSfLo /tmp/download-actionlint.bash \
+            https://raw.githubusercontent.com/rhysd/actionlint/v1.7.7/scripts/download-actionlint.bash
+          bash /tmp/download-actionlint.bash 1.7.7 /tmp
+          /tmp/actionlint
+        shell: bash
 
   zizmor:
     name: zizmor

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -1,0 +1,18 @@
+# zizmor baseline configuration.
+#
+# Suppress accepted-as-intentional findings here, with rule_id + path +
+# rationale. Empty today — accumulate suppressions as real findings are
+# reviewed and either fixed or formally accepted.
+#
+# Format: https://woodruffw.github.io/zizmor/configuration/
+#
+# Example for future reference:
+#
+# rules:
+#   dangerous-triggers:
+#     ignore:
+#       - path: .github/workflows/pr.yaml
+#         comment: |
+#           pull_request_target is intentional here so PR validation runs
+#           from main's trusted version of the workflow rather than the
+#           PR-author-controlled HEAD. See S2 hardening notes.


### PR DESCRIPTION
Same pattern as [#96](https://github.com/Chris-Wolfgang/ETL-Csv/pull/96) (0.1.0 protected baseline) and [#103](https://github.com/Chris-Wolfgang/ETL-Csv/pull/103) (benchmarks.yaml split).

Splits the new `workflow-security.yaml` out of the 0.2.0 release PR [#125](https://github.com/Chris-Wolfgang/ETL-Csv/pull/125) so it can be **admin-bypass merged** without forcing the rest of 0.2.0 through the same path.

`pr.yaml`'s Detect .NET Projects guard treats any change to `.github/workflows/*.yaml` as protected — by design, since CI can't self-validate changes to its own workflow set.

## Files

| File | Source |
|---|---|
| `.github/workflows/workflow-security.yaml` | verbatim from `vNext` (landed via #115) |
| `.github/actionlint.yaml` | actionlint baseline config — unprotected, but the workflow reads it |
| `.zizmor.yml` | zizmor baseline config — unprotected, but the workflow reads it |

Bundled the unprotected config files alongside so workflow-security.yaml has its config the first time it runs from main.

## Merge plan

1. **Admin-bypass merge** this PR into main. The Detect .NET Projects guard will trip here too — expected; the whole point is to add that workflow.
2. PR #125's CI re-runs. Now sees zero protected-file deltas → 0.2.0 ships through normal CI.

## Bypass safety note

Per `feedback_admin_bypass_all_or_nothing.md` — admin Bypass and merge waives ALL ruleset rules at once. This PR has 0 threads and 0 review state to waive; risk is limited to the protected-files check itself. Same posture as #96 and #103.